### PR TITLE
Add ability to pass syntax

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ export const config = {
 			'number'
 		],
 		default: 80
+	},
+	syntax: {
+		description: 'Use the SCSS syntax, to be able to format SCSS-style single line comments',
+		type: 'string'
 	}
 };
 


### PR DESCRIPTION
@sindresorhus this should be a fix for being able to pass the syntax in. I'm not sure how to test atom plugins locally, so not sure if this works or not. 

Resolves #2 
